### PR TITLE
feat(actions): restore task preamble log and fix clipboard keybindings

### DIFF
--- a/actions/runner.go
+++ b/actions/runner.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -274,6 +275,8 @@ func runGroupTask(
 
 	env := buildEnv(cfg, st, projName, proj)
 
+	emitTaskPreamble(ctx, handler, taskName, taskDir, cmds, proj, cfg, st, projName)
+
 	wrappedHandler := &searchForHandler{
 		inner:      handler,
 		searchFors: searchFors,
@@ -293,6 +296,56 @@ func runGroupTask(
 	}
 
 	return nil
+}
+
+// emitTaskPreamble writes a short header to the task log showing the working
+// directory, command, and any env vars injected by gitte (project env, env_when,
+// feature gates). It is emitted before the command starts so the log is
+// self-contained for debugging.
+func emitTaskPreamble(
+	ctx context.Context,
+	handler executor.OutputHandler,
+	taskName, taskDir string,
+	cmds []string,
+	proj config.ProjectConfig,
+	cfg *config.GitteConfig,
+	st *state.GitteState,
+	projName string,
+) {
+	emit := func(line string) {
+		_ = handler.HandleOutput(ctx, executor.Output{
+			Output:  []byte(line),
+			CmdName: taskName,
+			Stream:  executor.StdoutStream,
+		})
+	}
+
+	emit("  dir: " + taskDir)
+	emit("  cmd: " + strings.Join(cmds, " "))
+
+	// Collect only the vars gitte injects (not all of os.Environ).
+	injected := make(map[string]string)
+	for k, v := range proj.Env {
+		injected[k] = v
+	}
+	for k, v := range config.ResolveEnvWhen(proj.EnvWhen, runtime.GOARCH) {
+		injected[k] = v
+	}
+	for k, v := range extraEnvForProject(cfg, st, projName, proj) {
+		injected[k] = v
+	}
+	if len(injected) > 0 {
+		keys := make([]string, 0, len(injected))
+		for k := range injected {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			parts = append(parts, k+"="+injected[k])
+		}
+		emit("  env: " + strings.Join(parts, " "))
+	}
 }
 
 // extraEnvForProject returns the env vars injected by feature gates for a project.

--- a/actions/view.go
+++ b/actions/view.go
@@ -813,18 +813,28 @@ func (m *actionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "c":
 			if m.focusTask != "" {
 				text := m.buildCopyText(m.focusTask)
-				res := copyToClipboardOrFile(context.Background(), text, m.focusTask)
-				if res.err != nil {
-					m.clipboardMsg = res.err.Error()
+				method, err := copyToClipboard(context.Background(), text)
+				if err != nil {
+					m.clipboardMsg = "no clipboard tool available — use w to save to file"
 					m.clipboardOK = false
-				} else if res.method == "file" {
-					m.clipboardMsg = "saved to " + res.path
-					m.clipboardOK = true
-				} else if res.method == "osc52" {
+				} else if method == "osc52" {
 					m.clipboardMsg = "sent via OSC 52 (terminal clipboard)"
 					m.clipboardOK = true
 				} else {
 					m.clipboardMsg = "copied to clipboard"
+					m.clipboardOK = true
+				}
+				m.clipboardMsgExpiry = time.Now().Add(4 * time.Second)
+			}
+		case "w":
+			if m.focusTask != "" {
+				text := m.buildCopyText(m.focusTask)
+				res := writeToTempFile(text, m.focusTask)
+				if res.err != nil {
+					m.clipboardMsg = res.err.Error()
+					m.clipboardOK = false
+				} else {
+					m.clipboardMsg = "saved to " + res.path
 					m.clipboardOK = true
 				}
 				m.clipboardMsgExpiry = time.Now().Add(4 * time.Second)
@@ -1149,6 +1159,7 @@ func (m *actionsModel) View() tea.View {
 	if m.focusTask != "" {
 		parts = append(parts, "Enter/f: all logs")
 		parts = append(parts, "c: copy logs")
+		parts = append(parts, "w: save to file")
 	} else {
 		parts = append(parts, "Enter/f: focus logs")
 	}
@@ -1532,33 +1543,25 @@ func stripActANSI(s string) string {
 	return b.String()
 }
 
-// copyResult holds the outcome of a copy operation.
+// copyResult holds the outcome of a file-save operation.
 type copyResult struct {
-	method string // "clipboard", "file"
-	path   string // only set when method == "file"
-	err    error
+	path string
+	err  error
 }
 
-// copyToClipboardOrFile tries: native clipboard tools → OSC 52 → temp file.
-// Native tools are tried first because they give a real exit-code signal.
-// OSC 52 has no feedback mechanism (terminals silently ignore unsupported
-// sequences), so it is used as a best-effort fallback for SSH sessions where
-// native tools are unavailable.
-func copyToClipboardOrFile(ctx context.Context, text, taskName string) copyResult {
-	// 1. Native clipboard tools — reliable success/failure via exit code.
+// copyToClipboard tries native clipboard tools first, then OSC 52 as a
+// best-effort fallback for SSH sessions. Returns the method used ("clipboard"
+// or "osc52"), or an error if no tool is available.
+func copyToClipboard(ctx context.Context, text string) (string, error) {
 	if tryNativeClipboard(ctx, text) {
-		return copyResult{method: "clipboard"}
+		return "clipboard", nil
 	}
-
-	// 2. OSC 52: best-effort for SSH sessions. The sequence is written to the
-	// terminal but there is no way to confirm the terminal honored it. We fall
-	// through to a temp file only if stdout is not a terminal at all.
+	// OSC 52 has no feedback mechanism — terminals silently ignore unsupported
+	// sequences — but it is useful over SSH where native tools are absent.
 	if tryOSC52(text) {
-		return copyResult{method: "osc52"}
+		return "osc52", nil
 	}
-
-	// 3. Fallback: write to temp file.
-	return writeToTempFile(text, taskName)
+	return "", fmt.Errorf("no clipboard tool available")
 }
 
 // tryOSC52 writes the OSC 52 escape sequence to stdout.
@@ -1625,7 +1628,7 @@ func writeToTempFile(text, taskName string) copyResult {
 	if _, err := f.WriteString(text); err != nil {
 		return copyResult{err: fmt.Errorf("failed to write temp file: %w", err)}
 	}
-	return copyResult{method: "file", path: f.Name()}
+	return copyResult{path: f.Name()}
 }
 
 func fmtActionDuration(d time.Duration) string {

--- a/actions/view.go
+++ b/actions/view.go
@@ -820,6 +820,9 @@ func (m *actionsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else if res.method == "file" {
 					m.clipboardMsg = "saved to " + res.path
 					m.clipboardOK = true
+				} else if res.method == "osc52" {
+					m.clipboardMsg = "sent via OSC 52 (terminal clipboard)"
+					m.clipboardOK = true
 				} else {
 					m.clipboardMsg = "copied to clipboard"
 					m.clipboardOK = true
@@ -1536,16 +1539,22 @@ type copyResult struct {
 	err    error
 }
 
-// copyToClipboardOrFile tries: OSC 52 → native clipboard tools → temp file.
+// copyToClipboardOrFile tries: native clipboard tools → OSC 52 → temp file.
+// Native tools are tried first because they give a real exit-code signal.
+// OSC 52 has no feedback mechanism (terminals silently ignore unsupported
+// sequences), so it is used as a best-effort fallback for SSH sessions where
+// native tools are unavailable.
 func copyToClipboardOrFile(ctx context.Context, text, taskName string) copyResult {
-	// 1. OSC 52: works over SSH in modern terminals (iTerm2, kitty, WezTerm, etc.).
-	if tryOSC52(text) {
+	// 1. Native clipboard tools — reliable success/failure via exit code.
+	if tryNativeClipboard(ctx, text) {
 		return copyResult{method: "clipboard"}
 	}
 
-	// 2. Native clipboard tools.
-	if tryNativeClipboard(ctx, text) {
-		return copyResult{method: "clipboard"}
+	// 2. OSC 52: best-effort for SSH sessions. The sequence is written to the
+	// terminal but there is no way to confirm the terminal honored it. We fall
+	// through to a temp file only if stdout is not a terminal at all.
+	if tryOSC52(text) {
+		return copyResult{method: "osc52"}
 	}
 
 	// 3. Fallback: write to temp file.


### PR DESCRIPTION
## Changes

**Task log preamble (restored)**

Re-adds the `dir:` / `cmd:` / `env:` header printed at the top of each task log in the old implementation but not carried over to the Go rewrite. `emitTaskPreamble` emits:
- Working directory
- Full command string
- Any env vars gitte injects (project `env`, `env_when`, feature gates) — sorted, emitted only when non-empty

**Clipboard and save-to-file as separate keybindings**

Previously `c` silently fell back to writing a temp file if no clipboard tool was available. Now:

- **`c`** — clipboard only (native tools → OSC 52). Errors with "no clipboard tool available — use w to save to file" if nothing works.
- **`w`** — always writes a temp file and shows the path in the toast.

Both are shown in the help bar when a task is focused.