### PR TITLE
fix(gitops): clean failure display in TUI grid and post-run summary

### DIFF
--- a/gitops/view.go
+++ b/gitops/view.go
@@ -487,7 +487,21 @@ func (m *gitopsModel) printSummary() {
 		return
 	}
 	for _, e := range noteworthy {
-		fmt.Println(m.renderEntry(e, width))
+		if e.state == goStateFailed {
+			fmt.Printf(" %s %s  %s\n",
+				goFailStyle.Render("✗"),
+				goFailStyle.Render(strings.TrimPrefix(e.name, "gitops:")),
+				goDimStyle.Render(fmtDuration(e.elapsed)),
+			)
+			for _, line := range strings.Split(strings.TrimSpace(e.detail), "\n") {
+				if line != "" {
+					fmt.Printf("   %s\n", goDimStyle.Render(line))
+				}
+			}
+			fmt.Println()
+		} else {
+			fmt.Println(m.renderEntry(e, width))
+		}
 	}
 }
 
@@ -526,7 +540,6 @@ func (m *gitopsModel) renderEntry(e *goEntry, colW int) string {
 	case goStateFailed:
 		icon = goFailStyle.Render("✗")
 		nameStr = goFailStyle.Render(label)
-		extra = goFailStyle.Render("  " + e.detail)
 	}
 
 	line := fmt.Sprintf(" %s %s%s", icon, nameStr, extra)
@@ -564,6 +577,9 @@ func visibleWidth(s string) int {
 }
 
 func truncateToVisualWidth(s string, maxWidth int) string {
+	if maxWidth < 1 {
+		return ""
+	}
 	var result strings.Builder
 	vis := 0
 	inEsc := false
@@ -583,8 +599,8 @@ func truncateToVisualWidth(s string, maxWidth int) string {
 			escBuf.WriteRune(r)
 			continue
 		}
-		if vis >= maxWidth {
-			result.WriteString("\x1b[0m")
+		if vis >= maxWidth-1 {
+			result.WriteString("\x1b[0m…")
 			return result.String()
 		}
 		result.WriteRune(r)


### PR DESCRIPTION
## Problem

Git errors are often multiline (a header line + detail lines from stderr). The previous code stuffed `err.Error()` directly into the inline `extra` column of the live grid, which broke the multi-column layout and was silently hard-truncated at column width with no indication content was cut.

## Changes

**Live grid — no inline error text**

Failed entries now show only the icon and project name, matching the startup checks TUI style. The error is not useful at-a-glance in a dense grid anyway.

Before:
```
 ✗ cego/some-repo  exit status 128: fatal: repository 'https://gi…
```

After:
```
 ✗ cego/some-repo
```

**Post-run summary — multi-line failure blocks**

`printSummary` now renders each failed repo as a block instead of delegating to `renderEntry`.

Before:
```
 ✗ cego/some-repo  exit status 128: fatal: repository 'https://github.com/cego/foo.git' not found\nerror: Could not fetch origin
```

After:
```
 ✗ cego/some-repo  (1.3s)
   fatal: repository 'https://github.com/cego/foo.git' not found
   error: Could not fetch origin

 ✗ cego/other-repo  (0.8s)
   error: src refspec main does not match any
```

**`truncateToVisualWidth` — ellipsis on truncation**

Previously truncated silently mid-word. Now appends `…` so it is clear content was cut.

Before:
```
 ✗ cego/a-very-long-project-name-that-does-not-fi
```

After:
```
 ✗ cego/a-very-long-project-name-that-does-not-f…
```