### PR TITLE
fix(executor): reject duplicate task names with a clear error

### DIFF
--- a/executor/planner.go
+++ b/executor/planner.go
@@ -14,10 +14,11 @@ func ValidateNoCycles(tasks []Task) error {
 
 	taskSet := make(map[string]bool)
 	for _, t := range tasks {
-		taskSet[t.Name] = true
-		if _, ok := inDegree[t.Name]; !ok {
-			inDegree[t.Name] = 0
+		if taskSet[t.Name] {
+			return fmt.Errorf("duplicate task name %q", t.Name)
 		}
+		taskSet[t.Name] = true
+		inDegree[t.Name] = 0
 	}
 
 	for _, t := range tasks {

--- a/executor/planner_test.go
+++ b/executor/planner_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -40,6 +41,23 @@ func TestValidateNoCycles_UnknownDep(t *testing.T) {
 	}
 	if err := ValidateNoCycles(tasks); err == nil {
 		t.Error("expected error for unknown dep, got nil")
+	}
+}
+
+func TestValidateNoCycles_DuplicateNames(t *testing.T) {
+	tasks := []Task{
+		{Name: "a"},
+		{Name: "a"},
+	}
+	err := ValidateNoCycles(tasks)
+	if err == nil {
+		t.Fatal("expected error for duplicate task names, got nil")
+	}
+	if strings.Contains(err.Error(), "cycle") {
+		t.Errorf("duplicate names must not be reported as a cycle, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "a") {
+		t.Errorf("error should name the duplicate task, got: %v", err)
 	}
 }
 

--- a/gitops/discover.go
+++ b/gitops/discover.go
@@ -115,6 +115,8 @@ func Discover(ctx context.Context, cfg *config.GitteConfig, cwd string, mode out
 		return discoverErr
 	}
 
+	allRepos = dedupRepos(allRepos)
+
 	if len(allRepos) == 0 {
 		return nil
 	}
@@ -160,6 +162,23 @@ func Discover(ctx context.Context, cfg *config.GitteConfig, cwd string, mode out
 	runErr := syncExec.Execute(ctx)
 	syncView.Wait()
 	return runErr
+}
+
+// dedupRepos removes repos with duplicate Host+Path, preserving first-seen order.
+// Overlapping source configs (e.g. a repo reachable via two groups) would otherwise
+// produce colliding task names in the sync phase.
+func dedupRepos(repos []DiscoveredRepo) []DiscoveredRepo {
+	seen := make(map[string]bool, len(repos))
+	out := repos[:0]
+	for _, r := range repos {
+		key := r.Host + "/" + r.Path
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, r)
+	}
+	return out
 }
 
 // syncTransientDetailed clones or pulls a single transiently-discovered remote,

--- a/gitops/discover_test.go
+++ b/gitops/discover_test.go
@@ -1,0 +1,63 @@
+package gitops
+
+import "testing"
+
+func TestDedupRepos(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []DiscoveredRepo
+		want []DiscoveredRepo
+	}{
+		{
+			name: "no duplicates",
+			in: []DiscoveredRepo{
+				{Remote: "git@a:x/y.git", Host: "a", Path: "x/y"},
+				{Remote: "git@a:x/z.git", Host: "a", Path: "x/z"},
+			},
+			want: []DiscoveredRepo{
+				{Remote: "git@a:x/y.git", Host: "a", Path: "x/y"},
+				{Remote: "git@a:x/z.git", Host: "a", Path: "x/z"},
+			},
+		},
+		{
+			name: "duplicate host+path keeps first",
+			in: []DiscoveredRepo{
+				{Remote: "git@a:x/y.git", Host: "a", Path: "x/y"},
+				{Remote: "https://a/x/y.git", Host: "a", Path: "x/y"},
+			},
+			want: []DiscoveredRepo{
+				{Remote: "git@a:x/y.git", Host: "a", Path: "x/y"},
+			},
+		},
+		{
+			name: "same path different host kept",
+			in: []DiscoveredRepo{
+				{Remote: "git@a:x/y.git", Host: "a", Path: "x/y"},
+				{Remote: "git@b:x/y.git", Host: "b", Path: "x/y"},
+			},
+			want: []DiscoveredRepo{
+				{Remote: "git@a:x/y.git", Host: "a", Path: "x/y"},
+				{Remote: "git@b:x/y.git", Host: "b", Path: "x/y"},
+			},
+		},
+		{
+			name: "empty",
+			in:   nil,
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupRepos(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %d, want %d (%v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("index %d: got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `ValidateNoCycles` false-positived as a dependency cycle when two tasks shared a name, producing the malformed `dependency cycle detected among tasks: ` (with an empty member list). Kahn's `processed != len(tasks)` check counts unique nodes but compared against the raw slice length, so duplicates fell through the cycle branch even though no node had `in-degree > 0`.
- Detect duplicates during graph construction and return `duplicate task name "x"` instead.
- Dedupe discovered repos in `gitops.Discover` on `Host+"/"+Path` so overlapping source configs (a repo reachable via two GitLab groups, etc.) no longer collide on the sync-phase task name.
- Tests cover both: `TestValidateNoCycles_DuplicateNames` and `TestDedupRepos` (4 cases).