### PR TITLE
docs: use consistent example actions in help text and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ projects:
     remote: git@github.com:example/myservice.git
     default_branch: main
     actions:
-      up:
+      start:
         groups:
           local: ["docker", "compose", "up", "-d"]
-      down:
+      stop:
         groups:
           local: ["docker", "compose", "down"]
 ```
@@ -94,10 +94,10 @@ projects:
 **2.** Run the full pipeline:
 
 ```bash
-gitte run up local
+gitte run start local
 ```
 
-Gitte will run startup checks, pull all repos, then execute the `up` action for group `local` across all enabled projects.
+Gitte will run startup checks, pull all repos, then execute the `start` action for group `local` across all enabled projects.
 
 ---
 
@@ -124,11 +124,11 @@ Gitte will run startup checks, pull all repos, then execute the `up` action for 
 Arguments to `run` and `actions` are positional: `action [group] [projects]`.
 
 ```bash
-gitte run up                         # up action, all groups, all enabled projects
-gitte run up local                   # up action, group local, all enabled projects
-gitte run up local myservice         # up action, group local, project myservice only
-gitte run up local frontend+backend  # up action, group local, projects frontend and backend
-gitte run up+build                   # run up then build, all groups, all enabled projects
+gitte run start                         # start action, all groups, all enabled projects
+gitte run start local                   # start action, group local, all enabled projects
+gitte run start local myservice         # start action, group local, project myservice only
+gitte run start local frontend+backend  # start action, group local, projects frontend and backend
+gitte run start+test                    # run start then test, all groups, all enabled projects
 ```
 
 Use `*` or `all` as a wildcard. Combine multiple values with `+`.

--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -15,10 +15,10 @@ func newActionsCmd() *cobra.Command {
 		Long: `Run actions only on configured projects.
 
 Examples:
-  gitte actions up
-  gitte actions up sn
-  gitte actions up+build sn
-  gitte actions up sn evolution+promotion`,
+  gitte actions start
+  gitte actions start local
+  gitte actions start+test local
+  gitte actions start local frontend+backend`,
 		Args:              cobra.RangeArgs(1, 3),
 		ValidArgsFunction: actionArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,10 +20,10 @@ func newRunCmd() *cobra.Command {
 		Long: `Run the full pipeline: startup checks, git sync, then actions.
 
 Examples:
-  gitte run up
-  gitte run up sn
-  gitte run up+build sn
-  gitte run up sn evolution+promotion`,
+  gitte run start
+  gitte run start local
+  gitte run start+test local
+  gitte run start local frontend+backend`,
 		Args:              cobra.RangeArgs(0, 3),
 		ValidArgsFunction: actionArgsCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,12 +9,12 @@ All commands support the global flags `--config <path>`, `--cwd <path>`, and `--
 Full pipeline: startup checks → git sync → actions.
 
 ```bash
-gitte run up
-gitte run up local
-gitte run up local myservice
-gitte run up local frontend+backend
-gitte run up+build
-gitte run up --discover    # also fetch repos from configured sources first
+gitte run start
+gitte run start local
+gitte run start local myservice
+gitte run start local frontend+backend
+gitte run start+test
+gitte run start --discover    # also fetch repos from configured sources first
 ```
 
 Arguments:
@@ -29,9 +29,9 @@ Arguments:
 Run actions only, skipping startup checks and git sync. Same argument syntax as `run`.
 
 ```bash
-gitte actions up
-gitte actions up local
-gitte actions down local myservice
+gitte actions start
+gitte actions start local
+gitte actions stop local myservice
 ```
 
 ---

--- a/docs/config.md
+++ b/docs/config.md
@@ -115,8 +115,8 @@ projects:
     vars:                    # template variable overrides (optional)
       stack_name: myservice-custom
     actions:
-      up:
-        needs: [database]    # run after database:up completes
+      start:
+        needs: [database]    # run after database:start completes
         retry:
           attempts: 2
           delay: 10s
@@ -124,13 +124,13 @@ projects:
         groups:
           prod: ["docker", "stack", "deploy", "myservice-prod"]
           staging: ["docker", "compose", "up", "-d"]
-      down:
+      stop:
         groups:
           prod: ["docker", "stack", "rm", "myservice-prod"]
           staging: ["docker", "compose", "down"]
-      build:
+      test:
         groups:
-          "*": ["make", "build"]   # wildcard group matches any group argument
+          "*": ["make", "test"]   # wildcard group matches any group argument
 ```
 
 ### Remote URL formats
@@ -145,7 +145,7 @@ https://github.com/example/myservice.git →  github.com/example/myservice
 
 ### actions
 
-Each action maps group names to commands. When you run `gitte run up prod`, gitte executes the command under `groups.prod` for each enabled project that has an `up` action.
+Each action maps group names to commands. When you run `gitte run start prod`, gitte executes the command under `groups.prod` for each enabled project that has a `start` action.
 
 **needs** — list of project names that must complete this action successfully before this project starts. Gitte resolves the full dependency graph and runs independent tasks in parallel.
 
@@ -173,11 +173,11 @@ templates:
     vars:
       stack: "{{.project}}-prod"
     actions:
-      up:
+      start:
         groups:
           prod: ["docker", "stack", "deploy", "{{.stack}}"]
           staging: ["docker", "compose", "up", "-d"]
-      down:
+      stop:
         groups:
           prod: ["docker", "stack", "rm", "{{.stack}}"]
           staging: ["docker", "compose", "down"]
@@ -195,7 +195,7 @@ projects:
     vars:
       stack: "backend-custom-prod"   # override specific variable
     actions:
-      up:
+      start:
         needs: [database]            # add dependency on top of template
 ```
 
@@ -211,14 +211,14 @@ templates:
     vars:
       stack: "{{.project}}"
     actions:
-      down:
+      stop:
         groups:
           prod: ["docker", "stack", "rm", "{{.stack}}"]
 
   php-service:
     extends: [base-service]    # inherits all of base-service
     actions:
-      up:
+      start:
         needs: [database]
 
   full-service:
@@ -235,12 +235,12 @@ Multiple parents are merged left-to-right; the rightmost definition wins for con
 
 ```yaml
 groupIncludes:
-  sn: [cego]      # running group "sn" also runs group "cego"
-  ht: [cego]      # running group "ht" also runs group "cego"
-  cego: [streaming]   # transitive: "sn" and "ht" also pull in "streaming"
+  team-a: [shared]    # running group "team-a" also runs group "shared"
+  team-b: [shared]    # running group "team-b" also runs group "shared"
+  shared: [infra]     # transitive: "team-a" and "team-b" also pull in "infra"
 ```
 
-Expansion is **transitive** — if `sn` includes `cego` and `cego` includes `streaming`, then running group `sn` automatically includes both `cego` and `streaming` tasks.
+Expansion is **transitive** — if `team-a` includes `shared` and `shared` includes `infra`, then running group `team-a` automatically includes both `shared` and `infra` tasks.
 
 This replaces the need for `*` wildcard groups on infrastructure projects. Give an infrastructure project a specific group name and list it in `groupIncludes` for the teams that need it.
 
@@ -266,7 +266,7 @@ retry:
 projects:
   myservice:
     actions:
-      up:
+      start:
         retry:
           attempts: 3
           delay: 10s
@@ -292,8 +292,8 @@ Override per-action settings globally.
 
 ```yaml
 actionOverride:
-  down:
-    maxParallelization: 1   # run down actions one at a time
+  stop:
+    maxParallelization: 1   # run stop actions one at a time
 ```
 
 ---
@@ -316,7 +316,7 @@ Can also be defined per-action:
 projects:
   myservice:
     actions:
-      up:
+      start:
         searchFor:
           - regex: "port already in use"
             hint: "Port conflict — check for other running services"
@@ -401,7 +401,7 @@ Run discovery with:
 
 ```bash
 gitte gitops --discover
-gitte run up --discover    # discover, then sync, then run actions
+gitte run start --discover    # discover, then sync, then run actions
 ```
 
 ---


### PR DESCRIPTION
Aligns the examples in the CLI help text, README, and docs on one coherent naming scheme:

- Example actions are now `start`, `stop`, and `test` throughout `gitte run` / `gitte actions` help, the README quick start and argument-syntax section, and the config reference.
- The `groupIncludes` example now uses `team-a` / `team-b` / `shared` / `infra` to better illustrate how transitive group expansion works for shared infrastructure.

No behaviour changes — help strings and markdown only.