### PR TITLE
ci: fix APT publish failure and bump actions to latest majors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -27,7 +27,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out
@@ -38,9 +38,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -53,9 +53,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -70,9 +70,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      # persist-credentials: false keeps checkout from leaving a GITHUB_TOKEN
+      # Authorization header in the git config. The formula push below
+      # authenticates as the GitHub App via the remote URL, and a persisted
+      # header would take precedence over it.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -79,6 +85,7 @@ jobs:
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
+          sudo apt-get update
           sudo apt-get install -y dpkg-dev apt-utils rclone
 
           DESCRIPTION="Developer environment orchestration tool"
@@ -126,7 +133,7 @@ jobs:
       - name: Generate app token for formula push
         if: github.ref_type == 'tag'
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -145,7 +152,6 @@ jobs:
 
           git config user.email "noc+gitte@cego.dk"
           git config user.name "CI"
-          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/cego/gitte"
           git fetch origin main
           git checkout main


### PR DESCRIPTION
## Why

The [2.1.6 release run](https://github.com/cego/gitte/actions/runs/31380207686/job/93428481154) failed in **Publish to APT**:

```
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/universe/r/rclone/rclone_1.60.1%2bdfsg-3ubuntu0.24.04.5_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

The step ran `apt-get install rclone` with no `apt-get update`, so apt asked the mirror for the `rclone` version baked into the runner image. Ubuntu has since published a newer one and dropped that `.deb` from the pool → 404 → exit 100. `dpkg-dev` and `apt-utils` were already present; only `rclone` needed downloading.

Fallout: the GitHub Release for 2.1.6 was created, but the APT repo never got 2.1.6 and the two Homebrew steps after it were skipped, so the formula wasn't bumped either.

## What

- `apt-get update` before the install in the APT publish step.
- Bump the actions that GitHub was force-migrating off Node 20 (the `release: .github#2` annotation on that run):

  | action | before | after |
  |---|---|---|
  | `actions/checkout` | v4 | v7 |
  | `actions/setup-go` | v5 | v7 |
  | `actions/upload-artifact` | v4 | v7 |
  | `actions/create-github-app-token` | v1 | v3 |

  `golangci/golangci-lint-action` was already on the current major (v9).

### One non-obvious interaction

`checkout` v6 [moved persisted credentials](https://github.com/actions/checkout/pull/2286) out of `.git/config` into a separate file wired up via `includeIf.gitdir:<gitdir>.path`. The release job's formula push relied on `git config --unset-all http.https://github.com/.extraheader` to drop the `GITHUB_TOKEN` header before pointing `origin` at a URL carrying the GitHub App token — under v6+ that unset is a no-op (it's guarded by `|| true`, so it fails silently) and the `GITHUB_TOKEN` `Authorization` header would win over the app token in the remote URL, pushing to `main` as the wrong identity.

Fixed at the source instead: the release job checks out with `persist-credentials: false`, so there is no header to unset, and the now-dead `--unset-all` line is removed. Nothing else in that job needs persisted git credentials — `gh release create` authenticates via `GH_TOKEN`.

## Reviewer checks

Verified against upstream release notes: `setup-go` v6's [toolchain handling change](https://github.com/actions/setup-go/pull/460) is low risk here since `go.mod` pins `go 1.25.0` with no `toolchain` directive; `create-github-app-token` v2 dropped the underscore-style inputs but this workflow already used `app-id`/`private-key`; v3's only breaking change is proxy-related. `upload-artifact` v7's new `archive` input is opt-in.

## Recovery for 2.1.6

Re-running the failed job won't help — a tag-triggered run uses the workflow file from the tagged tree, which won't contain this fix. After merge, either move the tag (`git tag -f 2.1.6 && git push -f origin 2.1.6`) or cut 2.1.7. The latter is cleaner given a 2.1.6 GitHub Release already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)